### PR TITLE
javadoc-build errors and small extensions

### DIFF
--- a/src/com/angryelectron/thingspeak/Channel.java
+++ b/src/com/angryelectron/thingspeak/Channel.java
@@ -61,7 +61,7 @@ public class Channel {
      *
      * @param channelId Channel Id.
      * @param writeKey API Key for the channel. See
-     * https://thingspeak.com/channels/<channelId>#apikeys
+     * https://thingspeak.com/channels/&lt;channelId&gt;#apikeys
      */
     public Channel(Integer channelId, String writeKey) {
         this.isPublic = true;
@@ -74,9 +74,9 @@ public class Channel {
      *
      * @param channelId Channel Id.
      * @param writeKey Write API Key. See
-     * https://thingspeak.com/channels/<channelId>#apikeys.
+     * https://thingspeak.com/channels/&lt;channelId&gt;#apikeys.
      * @param readKey Read API Key. See
-     * https://thingspeak.com/channels/<channelId>#apikeys.
+     * https://thingspeak.com/channels/&lt;channelId&gt;#apikeys.
      */
     public Channel(Integer channelId, String writeKey, String readKey) {
         this.channelId = channelId;
@@ -207,7 +207,7 @@ public class Channel {
      * faster alternative to getting a Channel Feed and then calling
      * {@link Feed#getChannelLastEntry()}
      *
-     * @param options
+     * @param options Supported options: offset, status, and location.
      * @return Entry.
      * @throws UnirestException The request cannot be made.
      * @throws ThingSpeakException The request is invalid.

--- a/src/com/angryelectron/thingspeak/Channel.java
+++ b/src/com/angryelectron/thingspeak/Channel.java
@@ -310,4 +310,19 @@ public class Channel {
     public void getUserChannels() {
         throw new UnsupportedOperationException("Not implemented.");
     }
+	
+    /**
+     * Checks if a channel is available/reachable. Use this method if you want to avoid handling exceptions.
+     *
+     * @return channel availability
+     */
+    public boolean isAvailable() {
+        String url = APIURL + "/channels/" + this.channelId + "/feed.json" + "?key=" + this.readAPIKey + "&results=0";
+        try {
+            thingRequest(url);
+        } catch (UnirestException | ThingSpeakException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/com/angryelectron/thingspeak/Entry.java
+++ b/src/com/angryelectron/thingspeak/Entry.java
@@ -230,7 +230,7 @@ public class Entry {
         updateMap.put("tweet", tweet);
     }
 
-	/**
+    /**
      * Set the created_at date of an entry, since the rate limit of the public Thingspeak server is 15 sec
      * @param created_at date which will be send to thingspeak
      */

--- a/src/com/angryelectron/thingspeak/Entry.java
+++ b/src/com/angryelectron/thingspeak/Entry.java
@@ -232,7 +232,7 @@ public class Entry {
 
     /**
      * Set the created date of an entry. If not explicitly set, the channel update time is used.
-	 * Useful when entries are not created and updated at the same time (offline mode, queuing to avoid rate-limiting, etc.)
+     * Useful when entries are not created and updated at the same time (offline mode, queuing to avoid rate-limiting, etc.)
      * @param created date which will be send to thingspeak
      */
     public void setCreated(Date created) {

--- a/src/com/angryelectron/thingspeak/Entry.java
+++ b/src/com/angryelectron/thingspeak/Entry.java
@@ -230,6 +230,15 @@ public class Entry {
         updateMap.put("tweet", tweet);
     }
 
+	/**
+     * Set the created_at date of an entry, since the rate limit of the public Thingspeak server is 15 sec
+     * @param created_at date which will be send to thingspeak
+     */
+    public void setCreated_at(Date created_at) {
+        this.created_at = created_at;
+        updateMap.put("created_at", created_at);
+    }
+	
     /**
      * Get date on which this channel entry was created.  Use 
      * {@link FeedParameters#offset(java.lang.Integer)} to adjust timezones.

--- a/src/com/angryelectron/thingspeak/Entry.java
+++ b/src/com/angryelectron/thingspeak/Entry.java
@@ -231,12 +231,13 @@ public class Entry {
     }
 
     /**
-     * Set the created_at date of an entry, since the rate limit of the public Thingspeak server is 15 sec
-     * @param created_at date which will be send to thingspeak
+     * Set the created date of an entry. If not explicitly set, the channel update time is used.
+	 * Useful when entries are not created and updated at the same time (offline mode, queuing to avoid rate-limiting, etc.)
+     * @param created date which will be send to thingspeak
      */
-    public void setCreated_at(Date created_at) {
-        this.created_at = created_at;
-        updateMap.put("created_at", created_at);
+    public void setCreated(Date created) {
+        this.created_at = created;
+        updateMap.put("created_at", created);
     }
 	
     /**

--- a/src/com/angryelectron/thingspeak/log4j/ThingSpeakAppender.java
+++ b/src/com/angryelectron/thingspeak/log4j/ThingSpeakAppender.java
@@ -45,7 +45,7 @@ import org.apache.log4j.spi.LoggingEvent;
  *
  * <p>
  * Then create and configure a new appender. Use
- * {@link #configureChannel(java.lang.Integer, java.lang.String) configureChannel}
+ * {@link #configureChannel(Integer, String, String) configureChannel}
  * to configure the appender, or set via log4j.properties:</p>
  * <ul>
  * <li>log4j.appender.ThingSpeak=com.angryelectron.thingspeak.log4j.ThingSpeakAppender</li>
@@ -100,10 +100,10 @@ public class ThingSpeakAppender extends AppenderSkeleton {
      * (thingpspeak.com) will be used.
      */
     public void configureChannel(Integer channelNumber, String apiWriteKey, String url) {        
-            channel = new Channel(channelNumber, apiWriteKey);
-            if (url != null) {
-                channel.setUrl(url);
-            }
+        channel = new Channel(channelNumber, apiWriteKey);
+        if (url != null) {
+            channel.setUrl(url);
+        }
     }
     
     /**


### PR DESCRIPTION
**1. remove build errors**: the greater-than and less-than signs make problems when building with ant. see [log.txt](https://github.com/angryelectron/thingspeak-java/files/169122/log.txt).

**2. create setter for created_at**: since thingspeak update rate is at 15 sec for public limited I want to control the date by my self. For my project, I put the entries in a queue but set the created_at date before that happens. In another thread I deque them and send them to thingspeak.

**3. add feature to check availiabilty of a channel**: I used your lib for an android project and it can happen that a mobile phone loses internet connectivity. I check with this new method at a specific rate if the channel/internet connectivity is available again.
